### PR TITLE
[PBW-5862] - Disabling Hazmat logging by default

### DIFF
--- a/js/utils/InitModules/InitOOHazmat.js
+++ b/js/utils/InitModules/InitOOHazmat.js
@@ -1,8 +1,21 @@
 require("./InitOOUnderscore.js");
 
+var hazmatConfig = {};
+
+// 'debugHazmat' flag needs to be set before plugins are loaded. If we added
+// this flag to the OO namespace, it would be overriden during plugin initalization,
+// so we need to use a global var instead
+if (window && !window.debugHazmat) {
+  hazmatConfig = {
+    fail: function() { return; },
+    warn: function() { return; },
+    log: function() { return; }
+  };
+}
+
 if ((!OO.HM) && (typeof window === 'undefined' || typeof window._ === 'undefined'))
 {
-  OO.HM = require('hazmat').create();
+  OO.HM = require('hazmat').create(hazmatConfig);
 }
 else if (!window.Hazmat)
 {
@@ -11,5 +24,5 @@ else if (!window.Hazmat)
 
 if (!OO.HM)
 {
-  OO.HM = window.Hazmat.noConflict().create();
+  OO.HM = window.Hazmat.noConflict().create(hazmatConfig);
 }

--- a/js/utils/InitModules/InitOOHazmat.js
+++ b/js/utils/InitModules/InitOOHazmat.js
@@ -7,9 +7,7 @@ var hazmatConfig = {};
 // so we need to use a global var instead
 if (window && !window.debugHazmat) {
   hazmatConfig = {
-    fail: function() { return; },
-    warn: function() { return; },
-    log: function() { return; }
+    warn: function() { return; }
   };
 }
 


### PR DESCRIPTION
This will turn off all Hazmat logging unless explicitly turned on by the Player Test Page. 

Since some plugins use this library and they are initialized before the player, there is no way to do this cleanly using the player's own debug config parameter.

A global debugHazmat variable had to be used because the OO namespace object seems to be overridden during plugin initialization.