### PR TITLE
[bugfix/PLAYER-3287] Language icon is not shown on Android for HLS

### DIFF
--- a/js/utils/environment.js
+++ b/js/utils/environment.js
@@ -120,6 +120,24 @@
       return OO.isAndroid && version >= 4;
     }());
 
+    /**
+     * Check if Android version > 4.3
+     * @returns {boolean} true if OS is not Android or Android version > 4.3 otherwise false
+     */
+    OO.isAndroidMajorVersion = (function() {
+      var isMajorVersion = true;
+      if (OO.isAndroid) {
+        var userAgent = OO.os.match(/Android [\d\.]*;/);
+        if (userAgent && userAgent.length) {
+          var userAgentLowerCase = userAgent[0].toLowerCase();
+          var version = userAgentLowerCase.match(/android\s([0-9\.]*)/)[1];
+          var minorAndroidVersion = 4.3;
+          isMajorVersion = parseFloat(version) > minorAndroidVersion;
+        }
+      }
+      return isMajorVersion;
+    }());
+
     OO.isRimDevice = (function() {
       return !!(OO.os.match(/BlackBerry/) || OO.os.match(/PlayBook/));
     }());


### PR DESCRIPTION
Function isAndroidMajorVersion was added.
It checkes if the OS is Android, and returns true if version of the OS > 4.3 otherwise returns false.