### PR TITLE
[PLAYER-5575] not able to play assets on firefox

### DIFF
--- a/js/utils/environment.js
+++ b/js/utils/environment.js
@@ -85,7 +85,7 @@
     }());
 
     OO.isWindows7 = (function() {
-      return OO.isWindows && OO.os.split('NT')[1].split(';')[0].trim() === '6.1';
+      return OO.isWindows && window.navigator.userAgent.match(/Windows NT [\d.]*/)[0].trim() === 'Windows NT 6.1';
     }());
 
     OO.isIos = (function() {


### PR DESCRIPTION
On Firefox the information stored at window.navigator.appVersion it is not the same as IE11. The fix is to use userAgent and get the information about the system version from it.